### PR TITLE
Fix build error

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,12 +5,13 @@ branches:
   - develop
 install:
   - cinst gitversion.portable -y
+  - ps: dotnet tool install --global dotnet-setversion
 before_build:
   - nuget restore
   - ps: $env:VERSION=$(gitversion /showvariable NuGetVersionV2)
 build_script:
   - ps: dotnet restore
-  - ps: cd src/AsyncEvent; dotnet setversion $env:VERSION; cd ../..
+  - ps: cd src/AsyncEvent; setversion $env:VERSION; cd ../..
   - ps: dotnet build
   - ps: dotnet pack --include-source --include-symbols -c Release -o out/
 test_script:

--- a/src/AsyncEvent/AsyncEvent.csproj
+++ b/src/AsyncEvent/AsyncEvent.csproj
@@ -11,7 +11,4 @@
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/TAGC/AsyncEvent</RepositoryUrl>
   </PropertyGroup>
-  <ItemGroup>
-    <DotNetCliToolReference Include="dotnet-setversion" Version="*" />
-  </ItemGroup>
 </Project>


### PR DESCRIPTION
When I tried to build on Linux it is errors with the following messages:

```
Microsoft (R) Build Engine version 16.4.0+e901037fe for .NET Core
Copyright (C) Microsoft Corporation. All rights reserved.

  Restore completed in 141.17 ms for /home/ultimaweapon/Workspace/zcoin/AsyncEvent/src/AsyncEvent/AsyncEvent.csproj.
  Restore completed in 141.17 ms for /home/ultimaweapon/Workspace/zcoin/AsyncEvent/examples/Thermometer/Thermometer.csproj.
/home/ultimaweapon/Workspace/zcoin/AsyncEvent/src/AsyncEvent/AsyncEvent.csproj : error NU1202: Package dotnet-setversion 2.1.0 is not compatible with netcoreapp2.2 (.NETCoreApp,Version=v2.2). Package dotnet-setversion 2.1.0 supports: netcoreapp2.1 (.NETCoreApp,Version=v2.1) / any [/home/ultimaweapon/Workspace/zcoin/AsyncEvent/async-event.sln]
/home/ultimaweapon/Workspace/zcoin/AsyncEvent/src/AsyncEvent/AsyncEvent.csproj : error NU1212: Invalid project-package combination for dotnet-setversion 2.1.0. DotnetToolReference project style can only contain references of the DotnetTool type  [/home/ultimaweapon/Workspace/zcoin/AsyncEvent/async-event.sln]
  Restore failed in 2.72 sec for /home/ultimaweapon/Workspace/zcoin/AsyncEvent/src/AsyncEvent/AsyncEvent.csproj.
  Restore completed in 10.27 sec for /home/ultimaweapon/Workspace/zcoin/AsyncEvent/test/AsyncEvent.Tests/AsyncEvent.Tests.csproj.
  Restore completed in 18.12 sec for /home/ultimaweapon/Workspace/zcoin/AsyncEvent/test/AsyncEvent.Tests/AsyncEvent.Tests.csproj.

Build FAILED.

/home/ultimaweapon/Workspace/zcoin/AsyncEvent/src/AsyncEvent/AsyncEvent.csproj : error NU1202: Package dotnet-setversion 2.1.0 is not compatible with netcoreapp2.2 (.NETCoreApp,Version=v2.2). Package dotnet-setversion 2.1.0 supports: netcoreapp2.1 (.NETCoreApp,Version=v2.1) / any [/home/ultimaweapon/Workspace/zcoin/AsyncEvent/async-event.sln]
/home/ultimaweapon/Workspace/zcoin/AsyncEvent/src/AsyncEvent/AsyncEvent.csproj : error NU1212: Invalid project-package combination for dotnet-setversion 2.1.0. DotnetToolReference project style can only contain references of the DotnetTool type  [/home/ultimaweapon/Workspace/zcoin/AsyncEvent/async-event.sln]
    0 Warning(s)
    2 Error(s)

Time Elapsed 00:00:19.26
```

So this PR fixes this error.