### PR TITLE
Fixes InvokeAsync on generic handler with no subscribers

### DIFF
--- a/src/AsyncEvent/AsyncEventHandler.cs
+++ b/src/AsyncEvent/AsyncEventHandler.cs
@@ -66,8 +66,8 @@ namespace AsyncEvent
         /// <param name="sender">The object firing the event.</param>
         /// <param name="eventArgs">The object containing the event data.</param>
         /// <returns>
-        /// A task that completes only when all registered handlers complete. A completed task is returned if the event handler is
-        /// null.
+        /// A <see cref="Task"/> that completes only when all registered handlers complete. A completed task is returned
+        /// if the event handler is <c>null</c>.
         /// </returns>
         public static Task InvokeAsync(this AsyncEventHandler eventHandler, object sender, EventArgs eventArgs)
         {
@@ -89,12 +89,20 @@ namespace AsyncEvent
         /// <param name="eventHandler">This event handler.</param>
         /// <param name="sender">The object firing the event.</param>
         /// <param name="eventArgs">The object containing the event data.</param>
-        /// <returns>A task that completes only when all registered handlers complete.</returns>
+        /// <returns>
+        /// A <see cref="Task"/> that completes only when all registered handlers complete. A completed task is returned
+        /// if the event handler is <c>null</c>.
+        /// </returns>
         public static Task InvokeAsync<TEventArgs>(
             this AsyncEventHandler<TEventArgs> eventHandler,
             object sender,
             TEventArgs eventArgs)
         {
+            if (eventHandler == null)
+            {
+                return Task.CompletedTask;
+            }
+
             var delegates = eventHandler.GetInvocationList().Cast<AsyncEventHandler<TEventArgs>>();
             var tasks = delegates.Select(it => it.Invoke(sender, eventArgs));
 

--- a/test/AsyncEvent.Tests/AsyncEventSpec.cs
+++ b/test/AsyncEvent.Tests/AsyncEventSpec.cs
@@ -82,11 +82,19 @@ namespace AsyncEvent.Tests
         }
 
         [Fact]
-        internal void Invoke_Async_Should_Return_Completed_Task_If_No_Handlers_Are_Subscribed()
+        internal void Non_Generic_Invoke_Async_Should_Return_Completed_Task_If_No_Handlers_Are_Subscribed()
         {
             var notifier = new NonGenericNotifier();
 
             notifier.OnSomethingHappening().IsCompleted.ShouldBeTrue();
+        }
+
+        [Fact]
+        internal void Generic_Invoke_Async_Should_Return_Completed_Task_If_No_Handlers_Are_Subscribed()
+        {
+            var notifier = new GenericNotifier();
+
+            notifier.OnSomethingHappening(3).IsCompleted.ShouldBeTrue();
         }
 
         [Fact]


### PR DESCRIPTION
Not sure why it did not check on a generic version.